### PR TITLE
Conditionally include a 'guid' property in info returned by validator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The callback is passed two arguments, `(err, info)`.
 - `version`: Version of the specification that the analyzed assertion
   corresponds to. Currently this will be either "1.0.0" or "0.5.0".
 
+- `guid`: The GUID of the assertion, as per the algorithm described in
+  the documentation for `getAssertionGUID`. If the assertion passed-in
+  was the literal object for a 0.5.0-style assertion, this will be
+  `null`, since there is no way to know what the URL of the assertion
+  is.
+
 - `signature`: JSON Web Signature representation of the assertion. This
   will only be present if the assertion came in as a JWS.
 

--- a/index.js
+++ b/index.js
@@ -16,9 +16,21 @@ function sha256(str) {
   return hash.digest('hex');
 }
 
+function hostedAssertionGUID(urlOrAssertion) {
+  if (typeof(urlOrAssertion) != "string")
+    urlOrAssertion = urlOrAssertion.verify.url;
+  return sha256('hosted:' + urlOrAssertion);
+}
+
+function signedAssertionGUID(assertion) {
+  var urlParts = urlParse(assertion.verify.url);
+  var issuerOrigin = urlParts.protocol + '//' + urlParts.host;
+  return sha256('signed:' + assertion.uid + ':' + issuerOrigin);
+}
+
 function getAssertionGUID(urlOrSignature, callback) {
   if (isUrl(urlOrSignature))
-    return callback(null, sha256('hosted:' + urlOrSignature));
+    return callback(null, hostedAssertionGUID(urlOrSignature));
   unpackJWS(urlOrSignature, function(err, payload) {
     if (err) return callback(err);
     var errors = validateAssertion(payload);
@@ -26,10 +38,7 @@ function getAssertionGUID(urlOrSignature, callback) {
       return callback(makeError('structure', 'invalid assertion structure', {
         assertion: errors
       }));
-    var urlParts = urlParse(payload.verify.url);
-    var issuerOrigin = urlParts.protocol + '//' + urlParts.host;
-    var hash = sha256('signed:' + payload.uid + ':' + issuerOrigin);
-    return callback(null, hash);
+    return callback(null, signedAssertionGUID(payload));
   });
 }
 
@@ -268,11 +277,11 @@ function getLinkedResources(structures, callback) {
   }, hollaback);
 }
 
-function validateHosted(input, callback) {
+function validateHosted(input, callback, originalUrl) {
   if (!isObject(input))
     return callback(makeError('input', 'input must be an object', { input: input }));
   if (isOldAssertion(input))
-    return fullValidateOldAssertion(input, callback)
+    return fullValidateOldAssertion(input, callback, originalUrl)
   if (!input.verify)
     return callback(makeError('input', 'missing `verify` structure', { input: input }));
   if (input.verify.type === 'signed')
@@ -289,7 +298,7 @@ function validateHostedUrl(input, callback) {
       result.error.field = 'assertion';
       return callback(result.error);
     }
-    return validateHosted(result.body, callback);
+    return validateHosted(result.body, callback, input);
   });
 }
 
@@ -348,7 +357,7 @@ function checkRevoked(list, assertion) {
     return makeError('verify-revoked', msg);
 }
 
-function fullValidateOldAssertion(assertion, callback) {
+function fullValidateOldAssertion(assertion, callback, originalUrl) {
   const structuralErrors = validateAssertion(assertion);
   if (structuralErrors)
     return callback(makeError('structure', structuralErrors));
@@ -357,6 +366,7 @@ function fullValidateOldAssertion(assertion, callback) {
       return callback(err);
     return callback(null, {
       version: '0.5.0',
+      guid: originalUrl ? hostedAssertionGUID(originalUrl) : null,
       structures: {
         assertion: assertion,
         badge: assertion.badge,
@@ -368,7 +378,7 @@ function fullValidateOldAssertion(assertion, callback) {
 }
 
 function fullValidateBadgeAssertion(assertion, callback) {
-  const data = {version: '1.0.0'};
+  const data = {version: '1.0.0', guid: hostedAssertionGUID(assertion)};
   async.waterfall([
     getLinkedStructures.bind(null, assertion),
     validateStructures,
@@ -399,6 +409,7 @@ function fullValidateSignedAssertion(signature, callback) {
     getLinkedStructures,
     validateStructures,
     function getResources(structures, callback) {
+      data.guid = signedAssertionGUID(structures.assertion);
       data.structures = structures;
       return getLinkedResources(structures, callback);
     },

--- a/test/full.test.js
+++ b/test/full.test.js
@@ -35,6 +35,7 @@ test('validate, signed', function (t) {
   });
   validator(signature, function (err, data) {
     t.notOk(err, 'no errors');
+    t.ok(/^[A-Za-z0-9]+$/.test(data.guid));
     t.same(data.signature, signature);
     t.same(str(data.resources['badge.image']), 'badge-image');
     t.end();
@@ -90,6 +91,7 @@ test('validate, new hosted', function (t) {
     .get('/revocation-list').reply(200, '{"found":true}')
   validator(assertion, function (err, data) {
     t.notOk(err, 'should have no errors');
+    t.ok(/^[A-Za-z0-9]+$/.test(data.guid));
     t.end();
   });
 });
@@ -112,6 +114,7 @@ test('validate, new hosted by url', function (t) {
     .get('/revocation-list').reply(200, '{"found":true}')
   validator(ORIGIN + '/assertion', function (err, data) {
     t.notOk(err, 'should have no errors');
+    t.ok(/^[A-Za-z0-9]+$/.test(data.guid));
     t.end();
   });
 });
@@ -161,6 +164,7 @@ test('validate, old style', function (t) {
     t.same(data.version, '0.5.0');
     t.same(data.structures.assertion.badge, data.structures.badge);
     t.same(data.structures.badge.criteria, originalCriteria);
+    t.equal(data.guid, null);
     t.end();
   });
 });
@@ -179,6 +183,7 @@ test('validate, old style by url', function (t) {
     t.same(data.version, '0.5.0');
     t.same(data.structures.assertion.badge, data.structures.badge);
     t.same(data.structures.badge.criteria, originalCriteria);
+    t.ok(/^[A-Za-z0-9]+$/.test(data.guid));
     t.end();
   });
 });


### PR DESCRIPTION
The only situation this doesn't work for is when a raw 0.5.0-style assertion object is passed into the validator: since there's no way to know the URL at which the object is hosted, there's no way to provide a GUID.
