### PR TITLE
Got rid of Makefile, made 'npm test' work on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-.PHONY: test verbose
-test:
-	./node_modules/.bin/tap test/*.test.js
-verbose:
-	node test/*.test.js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": "~0.10.0"
   },
   "scripts": {
-    "test": "make"
+    "test": "node node_modules/tap/bin/tap test/*.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Makefiles aren't that great for new contributors because on a Mac they require installing the XCode Tools, and they're yet another thing to install on Windows.
