### PR TITLE
Validate dataURIs for remote resources

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -1,3 +1,4 @@
+const dataUrl = require('dataurl');
 const async = require('async');
 const request = require('request');
 
@@ -48,6 +49,23 @@ function getUrl(urlObj, callback) {
       }))
     return callback(null, {});
   }
+  if (/^data:/i.test(url)) {
+    return process.nextTick(function () {
+      const doc = dataUrl.parse(url);
+
+      if (contentType && doc.mimetype !== contentType)
+        return callback(null, error({
+          code: 'content-type',
+          url: url,
+          expected: contentType,
+          received: doc.mimetype
+        }));
+
+      return callback(null, { body: doc.data });
+    })
+  }
+
+
   request({
     method: 'get',
     url: url,
@@ -111,4 +129,3 @@ function find(obj, path) {
     return aggr[part]
   }, obj);
 }
-

--- a/test/full.test.js
+++ b/test/full.test.js
@@ -12,8 +12,6 @@ var ORIGIN = 'https://example.org';
 var httpScope = nock(ORIGIN);
 var imageData = fs.readFileSync(path.join(__dirname, 'cc.large.png'));
 
-console.dir();
-
 test('validate, signed', function (t) {
   const assertion = generators['1.0.0-assertion']({
     verify: {

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -1,10 +1,14 @@
 const fs = require('fs');
+const path = require('path');
+const dataUrl = require('dataurl');
 const test = require('tap').test;
 const resources = require('../lib/resources');
 const nock = require('nock');
 
 const ORIGIN = 'https://example.org';
 const httpScope = nock(ORIGIN);
+
+var imageData = fs.readFileSync(path.join(__dirname, 'cc.large.png'));
 
 test('getUrl: required, missing', function (t) {
   resources.getUrl({
@@ -108,19 +112,27 @@ test('getUrl: json, parseable', function (t) {
 });
 
 test('getUrl: image data', function (t) {
-  const imgData = fs.readFileSync(__dirname + '/cc.large.png');
   httpScope
-    .get('/test').reply(200, imgData, {'content-type': 'image/png'})
+    .get('/test').reply(200, imageData, {'content-type': 'image/png'})
   resources.getUrl({
     url: ORIGIN + '/test',
     required: true
   }, function (ex, result) {
-    t.same(imgData, result.body);
+    t.same(imageData, result.body);
     t.end();
   });
 });
 
-
+test('getUrl: dataURL', function (t) {
+  resources.getUrl({
+    url: dataUrl.format({data: imageData, mimetype: 'image/png'}),
+    required: true,
+    'content-type': 'image/png',
+  }, function (ex, result) {
+    t.same(imageData, result.body);
+    t.end();
+  });
+})
 
 test('resources', function (t) {
   httpScope
@@ -157,4 +169,3 @@ test('resources', function (t) {
     t.end();
   });
 });
-


### PR DESCRIPTION
fixes #5 

According to [the spec](https://github.com/mozilla/openbadges/wiki/Assertions#badgeassertion) we should be supporting data URIs for image resources. While the synchronous validation step took this into account (`isAbsoluteUrlOrDataURI`), the remote resource validation step did not and would assume anything coming into those fields was a remote resource.

I've fixed it so that the remote resource gathering library tests the URL first to check if it's a data URI and processes it differently if so. Note that while dataURI parsing can happen synchronously, I've wrapped the logic in a `process.nextTick` [to ensure that the call always happens async](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
