### PR TITLE
Fix to issue #30 

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,6 +388,7 @@ function unpackJWS(signature, callback) {
   const payload = jsonParse(parts.payload);
   if (!payload)
     return callback(makeError('jws-payload-parse'));
+  payload.header = parts.header;  // adding header information
   return callback(null, payload)
 }
 
@@ -457,9 +458,10 @@ function fullValidateSignedAssertion(signature, callback) {
       return getLinkedResources(structures, callback);
     },
     function verifySignature(resources, callback) {
+      algorithm = data.structures.assertion.header.alg;
       data.resources = resources;
       const publicKey = resources['assertion.verify.url'];
-      if (!jws.verify(signature, publicKey))
+      if (!jws.verify(signature, algorithm, publicKey))
         return callback(makeError('verify-signature'))
       return callback(null, resources);
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dataurl": "~0.1.0",
     "request": "~2.14.0",
     "async": "~0.2.5",
-    "jws": "0.2.2",
+    "jws": "~3.1.0",
     "deep-equal": "0.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request is a fix to the issue described here https://github.com/mozilla/openbadges-validator/issues/30.

The problem is that jws library that's bundle with openbadges-validator is too old and don't work properly with ECDSA signatures. This pull request updates the package dependencies version and some changes to the code in order to work with the new library version.
