### PR TITLE
Validate json

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,6 +362,10 @@ function validate(input, callback) {
       return validate.validateSigned(input, callback);
     if (isUrl(input))
       return validate.validateHostedUrl(input, callback);
+    if (isJson(input))
+      var json = JSON.parse(input);
+      if (typeof json.verify.url !== 'undefined' && isUrl(json.verify.url))
+        return validate.validateHostedUrl(json.verify.url, callback, '');
     return callback(makeError('input', 'not a valid signed badge or url', { input: input }));
   }
   return callback(makeError('input', 'input must be a string or object', { input: input }));
@@ -539,6 +543,10 @@ function regexToValidator(format, message) {
 
 function getInternalClass(thing) {
   return Object.prototype.toString.call(thing);
+}
+
+function isJson (str) {
+  try { JSON.parse(str); return true } catch(e) { return false }
 }
 
 const isUrl = regexToValidator(re.url, 'must be a URL');

--- a/index.js
+++ b/index.js
@@ -363,9 +363,9 @@ function validate(input, callback) {
     if (isUrl(input))
       return validate.validateHostedUrl(input, callback);
     if (isJson(input))
-      var json = JSON.parse(input);
-      if (typeof json.verify.url !== 'undefined' && isUrl(json.verify.url))
-        return validate.validateHostedUrl(json.verify.url, callback, '');
+      var url = urlFromAssertion(JSON.parse(input));
+      if (url)
+        return validate.validateHostedUrl(url, callback, '');
     return callback(makeError('input', 'not a valid signed badge or url', { input: input }));
   }
   return callback(makeError('input', 'input must be a string or object', { input: input }));
@@ -547,6 +547,15 @@ function getInternalClass(thing) {
 
 function isJson (str) {
   try { JSON.parse(str); return true } catch(e) { return false }
+}
+
+function urlFromAssertion (json) {
+  try {
+    var url = json.verify.url;
+    if (isUrl(url))
+      return url;
+    return false;
+  } catch(e) { return false; }
 }
 
 const isUrl = regexToValidator(re.url, 'must be a URL');


### PR DESCRIPTION
Before this PR, if `validate()` receives a valid JSON assertion string, it will give the error `"not a valid signed badge or url"`.

This PR takes a similar approach to (Badgr Server)[https://github.com/concentricsky/badgr-server], by [attempting to validate the response from the `verify.url` property](https://github.com/concentricsky/badgr-server/blob/6d23db5052c685bc0810a82cef73d99b9f651705/apps/verifier/utils.py#L82), instead of attempting to directly validate the JSON assertion object.